### PR TITLE
Feature/#17 jwt authentication

### DIFF
--- a/src/main/java/com/sns/yourconnection/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/sns/yourconnection/common/filter/JwtTokenFilter.java
@@ -1,6 +1,9 @@
 package com.sns.yourconnection.common.filter;
 
 
+import com.sns.yourconnection.model.user.dto.User;
+import com.sns.yourconnection.security.token.JwtTokenGenerator;
+import com.sns.yourconnection.service.UserService;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -8,6 +11,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -16,10 +23,62 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtTokenFilter extends OncePerRequestFilter {
 
+    private static final String BEARER = "Bearer ";
+    private final UserService userService;
+    private final JwtTokenGenerator jwtTokenGenerator;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
+        if (checkPublicApi(request, response, filterChain)) {
+            return;
+        }
+        try {
+            String accessToken = parseBearerToken(request);
+            User user = parseUserSpecification(accessToken);
+            configureAuthenticatedUser(request, user);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            //TODO: 예외 처리 구현
+        }
+        filterChain.doFilter(request, response);
+    }
 
+    private boolean checkPublicApi(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws IOException, ServletException {
+        if (request.getRequestURI().startsWith("/public-api/")) {
+            filterChain.doFilter(request, response);
+            return true;
+        }
+        return false;
+    }
+
+    private String parseBearerToken(HttpServletRequest request) {
+        String authorization = extractAuthorization(request);
+        log.info("[JwtTokenFilter] Extract authorization for Jwt token: {}", authorization);
+        return authorization.split(" ")[1];
+    }
+
+    private User parseUserSpecification(String accessToken) {
+        String username = jwtTokenGenerator.getUsername(accessToken);
+        log.info("[JwtTokenFilter] parsed username from token: {} ", username);
+        return userService.loadUserByUsername(username);
+    }
+
+    private void configureAuthenticatedUser(HttpServletRequest request, User user) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+            user,
+            null, user.getAuthorities());
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    private String extractAuthorization(HttpServletRequest request) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization == null || !authorization.startsWith(BEARER)) {
+            throw new RuntimeException();
+        }
+        return authorization;
     }
 }
 

--- a/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
@@ -6,6 +6,7 @@ import com.sns.yourconnection.model.user.param.UserJoinRequest;
 import com.sns.yourconnection.model.user.param.UserLoginRequest;
 import com.sns.yourconnection.model.user.result.UserJoinResponse;
 import com.sns.yourconnection.model.user.result.UserLoginResponse;
+import com.sns.yourconnection.security.token.AccessToken;
 import com.sns.yourconnection.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,7 @@ public class UserPublicApiController {
     public ResponseSuccess<UserLoginResponse> login(@RequestBody UserLoginRequest userLoginRequest) {
         log.info("User is attempting to login with username: {}", userLoginRequest.getUsername());
 
-        String accessToken = userService.login(userLoginRequest);
+        AccessToken accessToken = userService.login(userLoginRequest);
         log.info("your connection login is success and issued access token");
 
         return response(UserLoginResponse.of(accessToken));

--- a/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
+++ b/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
@@ -9,6 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "status code 500 is occurred"),
 
+    INVALID_TOKEN_FORMED(HttpStatus.UNAUTHORIZED, "not support to this token`s formed"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "token is expired"),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "token signature is invalid"),
+    NOT_BEARER_TOKEN(HttpStatus.UNAUTHORIZED, "token is not start with BEARER or null"),
+
     DUPLICATED_USERNAME(HttpStatus.CONFLICT, "username is duplicated"),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "nickname is duplicated"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "invalid password"),

--- a/src/main/java/com/sns/yourconnection/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sns/yourconnection/exception/GlobalExceptionHandler.java
@@ -1,13 +1,15 @@
 package com.sns.yourconnection.exception;
 
 import com.sns.yourconnection.controller.response.ResponseError;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.RestClientException;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -36,6 +38,37 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseError> appExceptionHandler(AppException e) {
         log.warn("[AppException Occurs] message: {} HttpStatus: {}", e.getErrorCode().getMessage(),
             e.getErrorCode().getHttpStatus());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+            .body(ResponseError.response(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity<ResponseError> malformedJwtExceptionHandler() {
+        log.warn("[invalid token malformed] message: {}",
+            ErrorCode.INVALID_TOKEN_FORMED.getMessage());
+        return ResponseEntity.status(ErrorCode.INVALID_TOKEN_FORMED.getHttpStatus())
+            .body(ResponseError.response(ErrorCode.INVALID_TOKEN_FORMED));
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    public ResponseEntity<ResponseError> signatureJwtExceptionHandler() {
+        log.warn("[Invalid token signature] message: {}",
+            ErrorCode.INVALID_TOKEN_SIGNATURE.getMessage());
+        return ResponseEntity.status(ErrorCode.INVALID_TOKEN_SIGNATURE.getHttpStatus())
+            .body(ResponseError.response(ErrorCode.INVALID_TOKEN_SIGNATURE));
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ResponseError> expiredJwtExceptionHandler() {
+        log.warn("[expired token] message: {}", ErrorCode.EXPIRED_TOKEN.getMessage());
+        return ResponseEntity.status(ErrorCode.EXPIRED_TOKEN.getHttpStatus())
+            .body(ResponseError.response(ErrorCode.EXPIRED_TOKEN));
+    }
+
+    @ExceptionHandler(MissingBearerTokenException.class)
+    public ResponseEntity<ResponseError> missingBearerTokenExceptionHandler(
+        MissingBearerTokenException e) {
+        log.warn("[Missing Bearer Token] message: {}", e.getErrorCode().getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
             .body(ResponseError.response(e.getErrorCode()));
     }

--- a/src/main/java/com/sns/yourconnection/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sns/yourconnection/exception/JwtAuthenticationEntryPoint.java
@@ -2,20 +2,29 @@ package com.sns.yourconnection.exception;
 
 import java.io.IOException;
 import javax.servlet.ServletException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationEntryPoint(
+        @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException) throws IOException, ServletException {
-
+        AuthenticationException authException) {
+        resolver.resolveException(request, response, null,
+            (Exception) request.getAttribute("exception"));
     }
 }

--- a/src/main/java/com/sns/yourconnection/exception/MissingBearerTokenException.java
+++ b/src/main/java/com/sns/yourconnection/exception/MissingBearerTokenException.java
@@ -1,0 +1,12 @@
+package com.sns.yourconnection.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.naming.AuthenticationException;
+
+@AllArgsConstructor
+@Getter
+public class MissingBearerTokenException extends AuthenticationException {
+    private ErrorCode errorCode;
+}

--- a/src/main/java/com/sns/yourconnection/model/user/result/UserLoginResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/user/result/UserLoginResponse.java
@@ -1,5 +1,6 @@
 package com.sns.yourconnection.model.user.result;
 
+import com.sns.yourconnection.security.token.AccessToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +11,11 @@ import lombok.NoArgsConstructor;
 public class UserLoginResponse {
 
     private String accessToken;
+    private String grantType;
+    private Long expiresIn;
 
-
-    public static UserLoginResponse of(String accessToken) {
-        return new UserLoginResponse(accessToken);
+    public static UserLoginResponse of(AccessToken accessToken) {
+        return new UserLoginResponse(accessToken.getAccessToken(), accessToken.getGrantType(),
+            accessToken.getExpiresIn());
     }
 }

--- a/src/main/java/com/sns/yourconnection/security/token/AccessToken.java
+++ b/src/main/java/com/sns/yourconnection/security/token/AccessToken.java
@@ -1,0 +1,18 @@
+package com.sns.yourconnection.security.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessToken {
+    private String accessToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AccessToken of(String accessToken, String grantType, Long expiresIn) {
+        return new AccessToken(accessToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/security/token/JwtTokenGenerator.java
+++ b/src/main/java/com/sns/yourconnection/security/token/JwtTokenGenerator.java
@@ -1,0 +1,63 @@
+package com.sns.yourconnection.security.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    @Value("${jwt.token.key}")
+    private String key;
+    @Value("${jwt.access-expired}")
+    private Long accessExpiredTimeMs;
+    @Value("${jwt.refresh-expired}")
+    private Long refreshExpiredTimeMs;
+
+
+    public AccessToken generateAccessToken(String username) {
+        return AccessToken.of(createJwtToken(username), BEARER_TYPE, accessExpiredTimeMs);
+    }
+
+    private String createJwtToken(String username) {
+        Claims claims = Jwts.claims();
+        claims.put("username", username);
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + accessExpiredTimeMs))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+        return token;
+    }
+
+    public String createRefreshToken(String userName, Long expireTimeMs) {
+        //TODO: refresh token 구현 중 수정 해야 함.
+        Claims claims = Jwts.claims();
+        claims.put("userName", userName);
+
+        return Jwts.builder()
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpiredTimeMs))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    public String getUsername(String token) {
+        return extractClaim(token, key).get("username", String.class);
+    }
+
+    private Claims extractClaim(String token, String secretKey) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+    }
+
+    public String extractSubject(String token) {
+        return extractClaim(token, key).getSubject();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,11 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-
+jwt:
+  token:
+    key: ${JWT_TOKEN_KEY}
+  access-expired: 3600000 #1시간  #6000 5초?
+  refresh-expired: 86400000   # 1 day
 ---
 spring:
   config:


### PR DESCRIPTION
## Summary

JWT Authentication

## Details
### Jwt token, filter 구현
- 기존 로그인 임의의 String token 반환 -> jwt 
  access token 반환으로 변경
- token에 대한 세부 설정 값 yaml 파일에서 
  바인딩
- access token 만료 기한 수정될 가능성 0
- user 인증을 위한 jwt filter 구현 
- jwt 예외로직 구현해야 함 
-  refresh token TODO list에 남겨놓음
### Jwt 예외 처리
- jwt filter에서 발생하는 예외를
  GlobalExceptionHandler에서 처리 할 수 있도록 JwtAuthenticationEntryPointentry 에서
  HandlerExceptionResolver 사용하여 처리

- request 에서 넘어온 Authorization 접두사에 BEARER이 없거나 파싱하는 과정에서 발생되는
  ‘Index out of bounces ‘ 에 대한 예외를 missingBearerTokenExceptionHandler 통해
  커스텀 예외 처리(Jwt 에서는 해당 사항에 대한 특별한 예외 제공하지 x)


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #17 
