### PR TITLE
Feature/#21 post create

### DIFF
--- a/src/main/java/com/sns/yourconnection/common/annotation/AuthUser.java
+++ b/src/main/java/com/sns/yourconnection/common/annotation/AuthUser.java
@@ -1,0 +1,11 @@
+package com.sns.yourconnection.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}

--- a/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.sns.yourconnection.common.configuration;
+
+import com.sns.yourconnection.common.resolver.AuthenticateUserResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        Stream.of(
+            new AuthenticateUserResolver()
+        ).forEach(resolvers::add);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditConfig.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditConfig.java
@@ -1,0 +1,15 @@
+package com.sns.yourconnection.common.configuration.auditor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditorAwareImpl.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditorAwareImpl.java
@@ -1,0 +1,29 @@
+package com.sns.yourconnection.common.configuration.auditor;
+
+
+import com.sns.yourconnection.model.user.dto.User;
+import com.sns.yourconnection.utils.ClassUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Slf4j
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    /*
+    AuditEntity 의 createBy,updatedBy의 값을 SecurityContext 에 저장된 user의 username으로 등록하기 위함
+     */
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext())
+            .map(SecurityContext::getAuthentication)
+            .filter(Authentication::isAuthenticated)
+            .map(Authentication::getPrincipal)
+            .map(principal -> ClassUtil.castingInstance(principal, User.class))
+            .map(User::getUsername);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
+++ b/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
@@ -1,0 +1,24 @@
+package com.sns.yourconnection.common.resolver;
+
+import com.sns.yourconnection.common.annotation.AuthUser;
+import com.sns.yourconnection.utils.ClassUtil;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticateUserResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(AuthUser.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return ClassUtil.getUserFromAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
+++ b/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
@@ -11,13 +11,15 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class AuthenticateUserResolver implements HandlerMethodArgumentResolver {
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterAnnotation(AuthUser.class) != null;
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return ClassUtil.getUserFromAuthentication(authentication);
     }

--- a/src/main/java/com/sns/yourconnection/controller/PostApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/PostApiController.java
@@ -1,8 +1,14 @@
 package com.sns.yourconnection.controller;
 
+import static com.sns.yourconnection.controller.response.ResponseSuccess.response;
+
 import com.sns.yourconnection.common.annotation.AuthUser;
+import com.sns.yourconnection.controller.response.ResponseSuccess;
+import com.sns.yourconnection.model.post.dto.Post;
 import com.sns.yourconnection.model.post.param.PostRequest;
+import com.sns.yourconnection.model.post.result.PostResponse;
 import com.sns.yourconnection.model.user.dto.User;
+import com.sns.yourconnection.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -14,10 +20,18 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class PostApiController {
 
+    private final PostService postService;
+
     @PostMapping("")
-    public void createPost(@RequestBody PostRequest postCreateRequest,
+    public ResponseSuccess<PostResponse> createPost(@RequestBody PostRequest postCreateRequest,
         @AuthUser User user) {
         log.info("Create a new post for user: {}. Request details: postCreateRequest: {}",
             user.getId(), postCreateRequest);
+
+        Post post = postService.createPost(postCreateRequest, user);
+        PostResponse postResponse = PostResponse.fromPost(post);
+        log.info("Post created successfully. Post details:{}", postResponse);
+
+        return response(postResponse);
     }
 }

--- a/src/main/java/com/sns/yourconnection/controller/PostApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/PostApiController.java
@@ -1,0 +1,23 @@
+package com.sns.yourconnection.controller;
+
+import com.sns.yourconnection.common.annotation.AuthUser;
+import com.sns.yourconnection.model.post.param.PostRequest;
+import com.sns.yourconnection.model.user.dto.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+@Slf4j
+public class PostApiController {
+
+    @PostMapping("")
+    public void createPost(@RequestBody PostRequest postCreateRequest,
+        @AuthUser User user) {
+        log.info("Create a new post for user: {}. Request details: postCreateRequest: {}",
+            user.getId(), postCreateRequest);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
+++ b/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
     DUPLICATED_USERNAME(HttpStatus.CONFLICT, "username is duplicated"),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "nickname is duplicated"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "invalid password"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "user not found");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "user not found"),
+    POST_DOES_NOT_EXIST(HttpStatus.NOT_FOUND, "post does not exist");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sns/yourconnection/model/audit/AuditEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/audit/AuditEntity.java
@@ -1,0 +1,37 @@
+package com.sns.yourconnection.model.audit;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    protected String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    protected LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    protected String updatedBy;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+}

--- a/src/main/java/com/sns/yourconnection/model/post/dto/Post.java
+++ b/src/main/java/com/sns/yourconnection/model/post/dto/Post.java
@@ -1,0 +1,31 @@
+package com.sns.yourconnection.model.post.dto;
+
+import com.sns.yourconnection.model.post.entity.PostEntity;
+import com.sns.yourconnection.model.user.dto.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Post {
+
+    private Long id;
+    private String title;
+    private String content;
+    private User user;
+
+    public static Post fromEntity(PostEntity postEntity) {
+        return new Post(
+            postEntity.getId(),
+            postEntity.getTitle(),
+            postEntity.getContent(),
+            User.fromEntity(postEntity.getUser())
+        );
+    }
+
+    public Post translateContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+        return this;
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/post/dto/Post.java
+++ b/src/main/java/com/sns/yourconnection/model/post/dto/Post.java
@@ -2,6 +2,7 @@ package com.sns.yourconnection.model.post.dto;
 
 import com.sns.yourconnection.model.post.entity.PostEntity;
 import com.sns.yourconnection.model.user.dto.User;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,6 +13,10 @@ public class Post {
     private Long id;
     private String title;
     private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String createdBy;
+    private String updatedBy;
     private User user;
 
     public static Post fromEntity(PostEntity postEntity) {
@@ -19,13 +24,11 @@ public class Post {
             postEntity.getId(),
             postEntity.getTitle(),
             postEntity.getContent(),
+            postEntity.getCreatedAt(),
+            postEntity.getUpdatedAt(),
+            postEntity.getCreatedBy(),
+            postEntity.getUpdatedBy(),
             User.fromEntity(postEntity.getUser())
         );
-    }
-
-    public Post translateContent(String title, String content) {
-        this.title = title;
-        this.content = content;
-        return this;
     }
 }

--- a/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
@@ -1,5 +1,6 @@
 package com.sns.yourconnection.model.post.entity;
 
+import com.sns.yourconnection.model.audit.AuditEntity;
 import com.sns.yourconnection.model.user.entity.UserEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import javax.persistence.*;
 @SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id=?")
 @Where(clause = "deleted_at is NULL")
 @Table(name = "\"post\"")
-public class PostEntity {
+public class PostEntity extends AuditEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
@@ -1,0 +1,42 @@
+package com.sns.yourconnection.model.post.entity;
+
+import com.sns.yourconnection.model.user.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id=?")
+@Where(clause = "deleted_at is NULL")
+@Table(name = "\"post\"")
+public class PostEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private PostEntity(String title, String content, UserEntity user) {
+        this.title = title;
+        this.content = content;
+        this.user = user;
+    }
+
+    public static PostEntity of(String title, String content, UserEntity user) {
+        return new PostEntity(title, content, user);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/post/param/PostRequest.java
+++ b/src/main/java/com/sns/yourconnection/model/post/param/PostRequest.java
@@ -1,0 +1,15 @@
+package com.sns.yourconnection.model.post.param;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequest {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/sns/yourconnection/model/post/result/PostResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/post/result/PostResponse.java
@@ -17,12 +17,20 @@ public class PostResponse {
     private Long postId;
     private String title;
     private String content;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
 
     public static PostResponse fromPost(Post post) {
         return new PostResponse(
             post.getId(),
             post.getTitle(),
-            post.getContent()
+            post.getContent(),
+            post.getCreatedAt(),
+            post.getCreatedBy(),
+            post.getUpdatedAt(),
+            post.getUpdatedBy()
         );
     }
 }

--- a/src/main/java/com/sns/yourconnection/model/post/result/PostResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/post/result/PostResponse.java
@@ -1,0 +1,28 @@
+package com.sns.yourconnection.model.post.result;
+
+import com.sns.yourconnection.model.post.dto.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponse {
+
+    private Long postId;
+    private String title;
+    private String content;
+
+    public static PostResponse fromPost(Post post) {
+        return new PostResponse(
+            post.getId(),
+            post.getTitle(),
+            post.getContent()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/repository/PostRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.sns.yourconnection.repository;
+
+import com.sns.yourconnection.model.post.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+}

--- a/src/main/java/com/sns/yourconnection/service/PostService.java
+++ b/src/main/java/com/sns/yourconnection/service/PostService.java
@@ -1,0 +1,44 @@
+package com.sns.yourconnection.service;
+
+
+import com.sns.yourconnection.common.annotation.AuthUser;
+import com.sns.yourconnection.model.post.dto.Post;
+import com.sns.yourconnection.model.user.dto.User;
+import com.sns.yourconnection.repository.*;
+import com.sns.yourconnection.model.post.param.PostRequest;
+
+import com.sns.yourconnection.model.post.entity.PostEntity;
+import com.sns.yourconnection.model.user.entity.UserEntity;
+import com.sns.yourconnection.exception.AppException;
+import com.sns.yourconnection.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Post createPost(PostRequest postCreateRequest, User user) {
+        // post 작성 기능
+        UserEntity userEntity = getUserEntity(user);
+        PostEntity postEntity = PostEntity.of(postCreateRequest.getTitle(),
+            postCreateRequest.getContent(), userEntity);
+        log.info("PostEntity has created for create a new post with ID: {} title: {} content: {}"
+            , postEntity.getId(), postEntity.getTitle(), postEntity.getContent());
+        postRepository.save(postEntity);
+        return Post.fromEntity(postEntity);
+    }
+
+    public UserEntity getUserEntity(User user) {
+        return userRepository.findById(user.getId()).orElseThrow(() ->
+            new AppException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sns/yourconnection/utils/ClassUtil.java
+++ b/src/main/java/com/sns/yourconnection/utils/ClassUtil.java
@@ -1,0 +1,17 @@
+package com.sns.yourconnection.utils;
+
+import com.sns.yourconnection.model.user.dto.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+
+@Slf4j
+public class ClassUtil {
+
+    public static <T> T castingInstance(Object o, Class<T> clazz) {
+        return clazz != null && clazz.isInstance(o) ? clazz.cast(o) : null;
+    }
+
+    public static User getUserFromAuthentication(Authentication authentication) {
+        return castingInstance(authentication.getPrincipal(), User.class);
+    }
+}


### PR DESCRIPTION
## Summary

Post create 기능 개발

## Details
### post entity 생성
- id, title, content, user 컬럼 생성
- soft delete 방식으로 delete 하기 위해
  @SQLDelete 사용
### AuditEntity 구현
- 날짜, 작성자 정보등은 테이블마다 공통되기에
  상속 클래스  AuditiEntity  생성하여
  공통로직 줄이기
- Security context의 Principal을 안전하게
  캐스팅하기 위해 ClassUtil 클래스 생성
### AuthUser 어노테이션 생성
- Authentication 객체를 controller에서 직접요청받지 않고 resolver 형식으로 
 일관된 처리하기 위해 AuthUser 어노테이션 생성
### AuthUser 어노테이션 null 값 나오는 현상 수정
- AuthUser 어노테이션 사용할 경우 null 값 나오는 현상
- AuthUser 바인딩 클래스 WebMvcConfig에 등록하여 해결 
### Post create 기능 추가 
- post create 기능 추가
- Response 객체에 postResponse 를 반환



## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #21 
