### PR TITLE
Feature/#36 post update log

### DIFF
--- a/src/main/java/com/sns/yourconnection/model/audit/LogAuditEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/audit/LogAuditEntity.java
@@ -1,0 +1,31 @@
+package com.sns.yourconnection.model.audit;
+
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class LogAuditEntity {
+
+    @Column(name = "before_updated_at")
+    protected LocalDateTime beforeUpdatedAt;
+
+    @Column(name = "before_updated_by")
+    protected String beforeUpdatedBy;
+
+    @LastModifiedDate
+    @Column(name = "after_updated_at")
+    protected LocalDateTime afterUpdatedAt;
+
+    @LastModifiedBy
+    @Column(name = "after_updated_by")
+    protected String afterUpdatedBy;
+}

--- a/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/post/entity/PostEntity.java
@@ -7,7 +7,6 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -50,5 +49,10 @@ public class PostEntity extends AuditEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public void updateAndLog(PostLogEntity postLog) {
+        this.title = postLog.getAfterTitle();
+        this.content = postLog.getAfterContent();
     }
 }

--- a/src/main/java/com/sns/yourconnection/model/post/entity/PostLogEntity.java
+++ b/src/main/java/com/sns/yourconnection/model/post/entity/PostLogEntity.java
@@ -1,0 +1,64 @@
+package com.sns.yourconnection.model.post.entity;
+
+import com.sns.yourconnection.model.audit.LogAuditEntity;
+import com.sns.yourconnection.model.user.dto.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/*
+    post update log를 남기기위한 entity
+ */
+@Entity
+@Getter
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "\"post_log\"")
+public class PostLogEntity extends LogAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private PostEntity post;
+
+    @Column(name = "before_title")
+    private String beforeTitle;
+
+    @Column(name = "before_content", columnDefinition = "text")
+    private String beforeContent;
+
+    @Column(name = "after_title")
+    private String afterTitle;
+
+    @Column(name = "after_content", columnDefinition = "text")
+    private String afterContent;
+
+    private PostLogEntity(PostEntity post, String beforeTitle, String beforeContent,
+        LocalDateTime beforeUpdatedAt, String beforeUpdatedBy) {
+        this.post = post;
+        this.beforeTitle = beforeTitle;
+        this.beforeContent = beforeContent;
+        this.beforeUpdatedAt = beforeUpdatedAt;
+        this.beforeUpdatedBy = beforeUpdatedBy;
+    }
+
+    public static PostLogEntity of(PostEntity post, String beforeTitle, String beforeContent,
+        LocalDateTime beforeUpdatedAt, String beforeUpdatedBy) {
+        return new PostLogEntity(
+            post, beforeTitle, beforeContent, beforeUpdatedAt, beforeUpdatedBy
+        );
+    }
+
+    public void updateAndLog(String title, String content, PostEntity post) {
+        this.afterTitle = title;
+        this.afterContent = content;
+        post.updateAndLog(this);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/repository/PostLogRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/PostLogRepository.java
@@ -1,0 +1,9 @@
+package com.sns.yourconnection.repository;
+
+import com.sns.yourconnection.model.post.entity.PostLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLogRepository extends JpaRepository<PostLogEntity, Long> {
+}


### PR DESCRIPTION
## Summary

post update log 생성

## Details
- 차후 post 기능 분석 및 update 내역 관리를 
  위한 post update log 생성
- 이전 데이터와 동일할 경우 불필요한 log 객체 
  생성을 방지
- before, after 데이터의 특수성때문에 기존 
  Entity 와 다른 LogAuditEntity 생성
- 서비스 레이어의 규모가 커지는 시점에서 이를 줄일 수 있는 방법을 어느 정도 생각해보기

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #36 
