### PR TITLE
Feature/#45 rate limiting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+    //rate limit
+    implementation group: 'com.github.vladimir-bukhtoyarov', name: 'bucket4j-core', version: '7.0.0'
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
@@ -1,10 +1,12 @@
 package com.sns.yourconnection.common.configuration;
 
+import com.sns.yourconnection.common.interceptor.RateLimitingInterceptor;
 import com.sns.yourconnection.common.resolver.AuthenticateUserResolver;
 import com.sns.yourconnection.common.resolver.ValidatedPageRequestResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -13,7 +15,12 @@ import java.util.stream.Stream;
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+    private final RateLimitingInterceptor rateLimitingInterceptor;
 
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitingInterceptor);
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/com/sns/yourconnection/common/interceptor/RateLimitingInterceptor.java
+++ b/src/main/java/com/sns/yourconnection/common/interceptor/RateLimitingInterceptor.java
@@ -1,0 +1,96 @@
+package com.sns.yourconnection.common.interceptor;
+
+import com.sns.yourconnection.exception.ErrorCode;
+import com.sns.yourconnection.utils.RateLimitUtil;
+import com.sns.yourconnection.utils.HttpReqRespUtil;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.Refill;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitingInterceptor implements HandlerInterceptor {
+    private final Long BUCKET_CAPACITY = 100L;
+    private final Long BUCKET_TOKENS = 50L;
+    private final Duration CALLS_IN_SECONDS = Duration.ofSeconds(1);
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+    private final RateLimitUtil rateLimitUtil;
+
+    /**
+     * @param request  current HTTP request
+     * @param response current HTTP response
+     * @param handler  chosen handler to execute, for type and/or instance evaluation
+     * @return
+     * @throws Exception
+     * @apiNote `Retry-After` 설명: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+     */
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String clientIp = HttpReqRespUtil.getClientIp(request);
+        Bucket bucket = cache.computeIfAbsent(clientIp, key -> newBucket());
+        ConsumptionProbe consumptionProbe = bucket.tryConsumeAndReturnRemaining(1);
+        if (isRateLimitExceeded(request, response, clientIp, consumptionProbe)) return false;
+        return true;
+    }
+
+    /**
+     * @apiNote rate limit 발생여부에 따른 각각의 success, error response 를 생성 및 반환 합니다.
+     * * 'RateLimitCounter.checkLimitReachedThreshold()' 1시간에 10 번 이상의 rate limit 발생하는지 check 합니다.*
+     */
+    private boolean isRateLimitExceeded(HttpServletRequest request, HttpServletResponse response, String clientIp, ConsumptionProbe consumptionProbe) {
+        if (!consumptionProbe.isConsumed()) {
+            errorResponse(response, consumptionProbe);
+            log.warn("rate limit exceeded for client IP :{}  Refill in {} seconds  Request details: method = {} URI = {}"
+                    , clientIp, getRoundedSecondsToWaitForRefill(consumptionProbe), request.getMethod(), request.getRequestURI());
+            rateLimitUtil.checkLimitReachedThreshold(clientIp); // 만약에 1시간에 10번 이상의 Rate Limit 에러를 발생시키는 유저가 있다면 텔레그램 알림.
+            return true;
+        }
+        successResponse(response, consumptionProbe);
+        log.info("remaining token: {}", consumptionProbe.getRemainingTokens());
+        return false;
+    }
+
+    private Bucket newBucket() {
+        // 버킷의 총 크기 = 100 , 한 번에 충전되는 토큰 = 50 , 버킷 충전 시간 = 1초
+        return Bucket.builder()
+                .addLimit(Bandwidth.classic(
+                        BUCKET_CAPACITY, Refill.intervally(
+                                BUCKET_TOKENS, CALLS_IN_SECONDS)))
+                .build();
+    }
+
+    /**
+     * @apiNote 'X-RateLimit-RetryAfter', 'X-RateLimit-Limit', 'X-RateLimit-Remaining'
+     * 참고: https://sendbird.com/docs/chat/v3/platform-api/application/understanding-rate-limits/rate-limits
+     */
+    //TODO: response message ( custom response 객체 생성 후 구현 예정)
+    private void successResponse(HttpServletResponse response, ConsumptionProbe consumptionProbe) {
+        response.setHeader("X-RateLimit-Remaining", Long.toString(consumptionProbe.getRemainingTokens()));
+        response.setHeader("X-RateLimit-Limit", BUCKET_CAPACITY + ";w=" + CALLS_IN_SECONDS.getSeconds());
+    }
+
+    private void errorResponse(HttpServletResponse response, ConsumptionProbe consumptionProbe) {
+        response.setHeader("X-RateLimit-RetryAfter", Float.toString(getRoundedSecondsToWaitForRefill(consumptionProbe)));
+        response.setHeader("X-RateLimit-Limit", BUCKET_CAPACITY + ";w=" + CALLS_IN_SECONDS.getSeconds());
+        response.setStatus(ErrorCode.TOO_MANY_REQUESTS.getHttpStatus().value());
+    }
+
+    private float getRoundedSecondsToWaitForRefill(ConsumptionProbe consumptionProbe) {
+        float secondsToWaitForRefill = (float) TimeUnit.NANOSECONDS.toMillis(consumptionProbe.getNanosToWaitForRefill()) / 1000;
+        return (float) Math.round(secondsToWaitForRefill * 10) / 10;
+    }
+}

--- a/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
@@ -25,7 +25,8 @@ public class UserPublicApiController {
 
     @PostMapping("/join")
     public ResponseSuccess<UserJoinResponse> join(@RequestBody UserJoinRequest userJoinRequest) {
-        log.info("create a new User Request Details: {}", userJoinRequest);
+        log.info("create a new User Request Details: username: {}, nickname: {}",
+            userJoinRequest.getUsername(), userJoinRequest.getNickname());
 
         User user = userService.join(userJoinRequest);
         log.info("Successfully join for user: {}", user.getId());
@@ -34,7 +35,8 @@ public class UserPublicApiController {
     }
 
     @PostMapping("/login")
-    public ResponseSuccess<UserLoginResponse> login(@RequestBody UserLoginRequest userLoginRequest) {
+    public ResponseSuccess<UserLoginResponse> login(
+        @RequestBody UserLoginRequest userLoginRequest) {
         log.info("User is attempting to login with username: {}", userLoginRequest.getUsername());
 
         AccessToken accessToken = userService.login(userLoginRequest);

--- a/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
+++ b/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
@@ -7,18 +7,21 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    //internal server error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "status code 500 is occurred"),
 
     TELEGRAM_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
         "error occurred while sending a message on telegram"),
-
+    //translate
     TRANSLATION_PARSE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
         "error occurred while translating the text."),
     TRANSLATION_BUILD_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
         "translate build processing failed"),
     TRANSLATION_PARSE_NO_TEXT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,
         "cannot parse the text for translate"),
-
+    //rate limit
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "too many request"),
+    // application
     INVALID_TOKEN_FORMED(HttpStatus.UNAUTHORIZED, "not support to this token`s formed"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "token is expired"),
     INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "token signature is invalid"),
@@ -32,7 +35,6 @@ public enum ErrorCode {
     PAGE_SIZE_NOT_APPLICABLE(HttpStatus.BAD_REQUEST, "page size is too large"),
     CANNOT_FOLLOW_YOURSELF(HttpStatus.CONFLICT, "cannot follow yourself"),
     HAS_NOT_PERMISSION_TO_ACCESS(HttpStatus.UNAUTHORIZED, "has not permission to access"),
-
     NONE_MATCH(HttpStatus.NOT_FOUND, "can not find any match");
 
 

--- a/src/main/java/com/sns/yourconnection/service/UserService.java
+++ b/src/main/java/com/sns/yourconnection/service/UserService.java
@@ -36,10 +36,10 @@ public class UserService implements UserDetailsService {
             userJoinRequest.getUsername(), encoder.encode(userJoinRequest.getPassword()),
             userJoinRequest.getNickname());
 
-        log.info("UserEntity has created for join with ID: {} username: nickname: {}",
+        userRepository.save(userEntity);
+        log.info("UserEntity has created for join with ID: {} username:{} nickname: {}",
             userEntity.getId(), userEntity.getUsername(), userEntity.getNickname());
 
-        userRepository.save(userEntity);
         return User.fromEntity(userEntity);
     }
 

--- a/src/main/java/com/sns/yourconnection/utils/HttpReqRespUtil.java
+++ b/src/main/java/com/sns/yourconnection/utils/HttpReqRespUtil.java
@@ -1,0 +1,39 @@
+package com.sns.yourconnection.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+@Slf4j
+public class HttpReqRespUtil {
+    private static final String[] IP_HEADER_CANDIDATES = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+    };
+
+    /**
+     * @param request current HTTP request
+     * @return (String) client Ip
+     * @apiNote 'X-Forwarded-For' 설명: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+     */
+    public static String getClientIp(HttpServletRequest request) {
+        return Arrays.stream(IP_HEADER_CANDIDATES)
+                .map(request::getHeader)
+                .filter(ipAddress -> ipAddress != null && !ipAddress.isEmpty() && !"unknown".equalsIgnoreCase(ipAddress))
+                .map(ipAddress -> ipAddress.split(",")[0])
+                .findFirst()
+                .orElseGet(request::getRemoteAddr);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/utils/RateLimitUtil.java
+++ b/src/main/java/com/sns/yourconnection/utils/RateLimitUtil.java
@@ -1,0 +1,77 @@
+package com.sns.yourconnection.utils;
+
+import com.sns.yourconnection.service.thirdparty.telegram.TelegramService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitUtil {
+    private Map<String, RequestInfo> rateLimitErrorCounter = new ConcurrentHashMap<>();
+    private final TelegramService telegramService;
+
+    public void checkLimitReachedThreshold(String clientIp) {
+        RequestInfo requestInfo = rateLimitErrorCounter.computeIfAbsent(clientIp, key -> new RequestInfo());
+        if (!isApplyHandling(clientIp, requestInfo)) {
+            requestInfo.saveCount();
+        }
+    }
+
+    private boolean isApplyHandling(String clientIp, RequestInfo requestInfo) {
+        if (requestInfo.isWithinTimeWindow()) {
+            int count = requestInfo.incrementAndGetCount();
+            log.info("[Rate limit count] client IP : {}  limit count  : {} ", clientIp, count);
+            RateLimitHandling(clientIp, requestInfo, count);
+            return true;
+        }
+        return false;
+    }
+
+    private void RateLimitHandling(String clientIp, RequestInfo requestInfo, int count) {
+        if (count >= 10) {
+            alertRateLimit(clientIp);
+            requestInfo.resetCount();
+        }
+    }
+
+    private void alertRateLimit(String clientIp) {
+        telegramService.sendTelegram(String.format(" Rate limit is occurred 10 or more times for this client IP: %s", clientIp));
+    }
+
+    private static class RequestInfo {
+        private AtomicInteger count = new AtomicInteger(0);
+        private LocalDateTime lastRequestTime;
+
+        public int incrementAndGetCount() {
+            return this.count.incrementAndGet();
+        }
+
+        public boolean isWithinTimeWindow() {
+            LocalDateTime now = LocalDateTime.now();
+            if (lastRequestTime == null || ChronoUnit.HOURS.between(lastRequestTime, now) >= 1) {
+                lastRequestTime = now;
+                return false;
+            }
+            return true;
+        }
+
+        public void saveCount() {
+            count.set(1);
+            lastRequestTime = LocalDateTime.now();
+        }
+
+        public void resetCount() {
+            count.set(0);
+            lastRequestTime = LocalDateTime.now();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

rate limit 시스템 구축

## Details
### 의존성 주입
- rate limit 시스템을 구축하기 위한 bucket4j
 의존성 주입
### user log 수정
- log 메시지에 password 노출 수정
- log 메시지 속 id  null값 수정
### rate limit 구현
- 특정 기간 동안 클라이언트의 요청 수를 제어하기 위해 인터셉터에서 rate limit system구현하였습니다.
- 클라이언트는  IP 주소로 식별됩니다.
- 각 버킷은 100개의 토큰 용량을 가지고 있으며, 1초마다 50개의 토큰으로 리필됩니다.
- 1시간 안에 10번 이상의 rate limit 발생시 텔레그램으로 알림
- 1시간 동안의 요청은 해당 시간 창 내에서 카운트되며, 한 시간이 경과하면 카운터가 초기화됩니다.
### 특이사항
- 버킷, rate limit 카운트등의 설정값들은 변동 가능성 있습니다.
- 이후 rate limit 발생시킨 Ip에 대한 조치가 필요합니다.


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #45 
