### PR TITLE
Feature/#53 kakao login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    //OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     //telegram
     implementation 'org.telegram:telegrambots-spring-boot-starter:6.7.0'
     // SMTP 이메일 통신

--- a/src/main/java/com/sns/yourconnection/common/configuration/OAuth2Config.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/OAuth2Config.java
@@ -1,0 +1,22 @@
+package com.sns.yourconnection.common.configuration;
+
+import com.sns.yourconnection.security.oauth2.params.OAuth2ApiClient;
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class OAuth2Config {
+
+    @Bean
+    public Map<OAuth2Provider, OAuth2ApiClient> oAuth2ApiClientMap(List<OAuth2ApiClient> clients) {
+        return clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuth2ApiClient::oAuthProvider, Function.identity())
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sns/yourconnection/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -43,6 +44,14 @@ public class GlobalExceptionHandler {
         log.error("[TelegramError Occurs] error: {}", e.getErrorCode().name());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
             .body(ResponseError.response(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<ResponseError> restClientException(RestClientException e) {
+        telegramService.sendTelegram(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        log.error("[RestClientException Occurs] error: {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+            .body(ResponseError.response(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler(TranslateException.class)

--- a/src/main/java/com/sns/yourconnection/exception/OAuth2RestClientException.java
+++ b/src/main/java/com/sns/yourconnection/exception/OAuth2RestClientException.java
@@ -1,0 +1,14 @@
+package com.sns.yourconnection.exception;
+
+import org.springframework.web.client.RestClientException;
+
+public class OAuth2RestClientException extends RestClientException {
+
+    public OAuth2RestClientException(String msg) {
+        super(msg);
+    }
+
+    public OAuth2RestClientException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/OAuth2Provider.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/OAuth2Provider.java
@@ -1,0 +1,5 @@
+package com.sns.yourconnection.security.oauth2;
+
+public enum OAuth2Provider {
+    KAKAO, NAVER
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/params/KakaoApiClient.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/params/KakaoApiClient.java
@@ -1,0 +1,92 @@
+package com.sns.yourconnection.security.oauth2.params;
+
+import com.sns.yourconnection.exception.OAuth2RestClientException;
+import com.sns.yourconnection.security.oauth2.*;
+import com.sns.yourconnection.security.oauth2.result.KakaoUserProfile;
+import com.sns.yourconnection.security.oauth2.result.OAuth2UserProfile;
+import com.sns.yourconnection.security.token.KakaoTokens;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoApiClient implements OAuth2ApiClient {
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * @param params params.authorizationBody(): has authorization-code for issued access token
+     *               params.oAuth2Provider: inform provider
+     * @return access token
+     * @throws OAuth2RestClientException
+     */
+
+    @Override
+    public String requestAccessToken(OAuth2LoginParams params) throws OAuth2RestClientException {
+        // header
+        HttpHeaders httpHeaders = createUrlEncodedHttpHeaders();
+        // body
+        MultiValueMap<String, String> authorizationBody = params.authorizationBody();
+        authorizationBody.add("grant_type", GRANT_TYPE);
+        authorizationBody.add("client_id", clientId);
+        //request
+        HttpEntity<?> request = new HttpEntity<>(authorizationBody, httpHeaders);
+        //kakaoTokens
+        KakaoTokens kakaoTokens = restTemplate.postForObject(tokenUri, request, KakaoTokens.class);
+
+        if (kakaoTokens == null) {
+            throw new OAuth2RestClientException("[KakaoApiClient] Failed to retrieve access token.");
+        }
+        log.info("[KakaoApiClient] KakaoTokens is successfully issued");
+        return kakaoTokens.getAccessToken();
+    }
+
+    @Override
+    public OAuth2UserProfile requestUserProfile(String accessToken) {
+        // header
+        HttpHeaders httpHeaders = createUrlEncodedHttpHeaders();
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+        // body
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+        //request
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+        //response
+        ResponseEntity<String> stringResponseEntity = restTemplate.postForEntity(userInfoUri, request, String.class);
+        log.info("API response: stringResponseEntity.getBody(): {}", stringResponseEntity.getBody());
+        KakaoUserProfile kakaoUserProfile = restTemplate.postForObject(userInfoUri, request, KakaoUserProfile.class);
+        return kakaoUserProfile;
+    }
+
+    @Override
+    public OAuth2Provider oAuthProvider() {
+        return OAuth2Provider.KAKAO;
+    }
+
+    private HttpHeaders createUrlEncodedHttpHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return httpHeaders;
+    }
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/params/KakaoLoginParams.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/params/KakaoLoginParams.java
@@ -1,0 +1,25 @@
+package com.sns.yourconnection.security.oauth2.params;
+
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuth2LoginParams {
+    private String authorizationCode;
+
+    @Override
+    public OAuth2Provider oAuth2Provider() {
+        return OAuth2Provider.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> authorizationBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/params/OAuth2ApiClient.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/params/OAuth2ApiClient.java
@@ -1,0 +1,10 @@
+package com.sns.yourconnection.security.oauth2.params;
+
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import com.sns.yourconnection.security.oauth2.result.OAuth2UserProfile;
+
+public interface OAuth2ApiClient {
+    OAuth2Provider oAuthProvider();
+    String requestAccessToken(OAuth2LoginParams params) throws Exception;
+    OAuth2UserProfile requestUserProfile(String accessToken);
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/params/OAuth2LoginParams.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/params/OAuth2LoginParams.java
@@ -1,0 +1,10 @@
+package com.sns.yourconnection.security.oauth2.params;
+
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import org.springframework.util.MultiValueMap;
+
+public interface OAuth2LoginParams {
+    OAuth2Provider oAuth2Provider();
+
+    MultiValueMap<String, String> authorizationBody();
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/result/KakaoUserProfile.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/result/KakaoUserProfile.java
@@ -1,0 +1,52 @@
+package com.sns.yourconnection.security.oauth2.result;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserProfile implements OAuth2UserProfile {
+
+    //TODO: NAVER 로그인 구현 후 해당 부분 RECORE 구현 고려해보기
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+
+        private KakaoProfile profile;
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoProfile {
+
+        private String nickname;
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public OAuth2Provider getOAuthProvider() {
+        return OAuth2Provider.KAKAO;
+    }
+
+}

--- a/src/main/java/com/sns/yourconnection/security/oauth2/result/OAuth2UserProfile.java
+++ b/src/main/java/com/sns/yourconnection/security/oauth2/result/OAuth2UserProfile.java
@@ -1,0 +1,13 @@
+package com.sns.yourconnection.security.oauth2.result;
+
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+
+public interface OAuth2UserProfile {
+    String getEmail();
+
+    String getNickname();
+
+    OAuth2Provider getOAuthProvider();
+
+    String getId();
+}

--- a/src/main/java/com/sns/yourconnection/security/token/KakaoTokens.java
+++ b/src/main/java/com/sns/yourconnection/security/token/KakaoTokens.java
@@ -1,0 +1,30 @@
+package com.sns.yourconnection.security.token;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokens {
+    /**
+     * @apiNote 토큰 값 참고: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token-response
+     */
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/sns/yourconnection/service/thirdparty/oauth2/OAuth2LoginService.java
+++ b/src/main/java/com/sns/yourconnection/service/thirdparty/oauth2/OAuth2LoginService.java
@@ -1,0 +1,66 @@
+package com.sns.yourconnection.service.thirdparty.oauth2;
+
+import com.sns.yourconnection.exception.OAuth2RestClientException;
+import com.sns.yourconnection.model.dto.User;
+import com.sns.yourconnection.model.entity.user.UserEntity;
+import com.sns.yourconnection.repository.UserRepository;
+import com.sns.yourconnection.security.oauth2.OAuth2Provider;
+import com.sns.yourconnection.security.token.JwtTokenGenerator;
+import com.sns.yourconnection.security.token.AccessToken;
+import com.sns.yourconnection.security.oauth2.params.OAuth2ApiClient;
+import com.sns.yourconnection.security.oauth2.params.OAuth2LoginParams;
+import com.sns.yourconnection.security.oauth2.result.OAuth2UserProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenGenerator jwtTokenGenerator;
+    private final Map<OAuth2Provider, OAuth2ApiClient> oAuth2ApiClientMap;
+    private final BCryptPasswordEncoder encoder;
+
+    /**
+     * @param params from OAuth2 resource server(KAKAO, NAVER...)
+     * @return Access token generated JWT
+     */
+    public AccessToken login(OAuth2LoginParams params) {
+        OAuth2UserProfile oAuth2UserProfile = requestUserProfile(params);
+        return jwtTokenGenerator.generateAccessToken(getUsername(oAuth2UserProfile));
+    }
+
+    private String getUsername(OAuth2UserProfile oAuth2UserProfile) {
+        //TODO: Naver 로그인 구현 후 해당 부분 정리하기
+        String providerId = oAuth2UserProfile.getId();
+        String username = oAuth2UserProfile.getOAuthProvider().name() + providerId;
+        String dummyPassword = encoder.encode("{bcrypt}" + UUID.randomUUID());
+        String nickName = oAuth2UserProfile.getNickname();
+
+        return userRepository.findByUsername(username)
+            .map(User::fromEntity)
+            .map(User::getUsername)
+            .orElseGet(() ->
+                userRepository.save(UserEntity.of(username, dummyPassword, nickName))
+                    .getUsername()
+            );
+    }
+
+    public OAuth2UserProfile requestUserProfile(OAuth2LoginParams params) {
+        OAuth2ApiClient oAuth2ApiClient = oAuth2ApiClientMap.get(params.oAuth2Provider());
+        try {
+            String accessToken = oAuth2ApiClient.requestAccessToken(params);
+            OAuth2UserProfile oAuth2UserProfile = oAuth2ApiClient.requestUserProfile(accessToken);
+            return oAuth2UserProfile;
+        } catch (Exception e) {
+            throw new OAuth2RestClientException("Failed to retrieve access token.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,22 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_OAUTH2_CLIENT_ID}
+            client-secret: ${KAKAO_OAUTH2_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            client-authentication-method: POST
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## Summary

카카오 로그인 인증 구현

## Details
### OAuth2 의존성 주입 및 yaml 파일 설정
- OAuth2 클라이언트를 구성하기 위해 의존성을 추가했습니다.
- Kakao 계정으로 로그인하기 위해 필요한  yaml  설정값들을 구성하였습니다.
###  카카오 로그인 인증 설정
- kakao userprofile 설정하기
- Kakao 계정을 통해 로그인한 경우 해당 사용자 프로필 정보를 담기 위해 `KakaoUserProfile`클래스 성성
### 카카오 토큰 정보 생성하기
- `KakaoTokens`클래스를 사용하여 Kakao 계정으로부터 받아온 토큰 정보를 저장하고 처리할 수 있습니다.
### login params 설정
   - OAuth2 로그인을 위해 필요한 인증 정보(body)와 provider 정보를 제공하는 
  ` OAuth2LoginParams` 인터페이스를 생성하였습니다. 
### 카카오 로그인 인증 구현
- Kakao API와의 상호작용을 위해 필요한 
클라이언트 코드를 담기 위해 `KakaoApiClient` 클래스가 도입되었습니다.
- OAuth2 로그인 서비스를 처리하기 위한`OAuth2LoginService`를 구현하였습니다.
- `OAuth2LoginService` 는 사용자 인증 및 액세스 토큰 생성과 관련된 기능을 포함하고 있습니다.
- OAuth2 관련 REST 클라이언트 예외 처리를 위해 `OAuth2RestClientException` 클래스가 도입되었습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #53 
