### PR TITLE
Feature/#79 admin report develop

### DIFF
--- a/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/WebMvcConfig.java
@@ -1,10 +1,13 @@
 package com.sns.yourconnection.common.configuration;
 
+import com.sns.yourconnection.common.converter.ContentActivityConverter;
+import com.sns.yourconnection.common.converter.UserActivityConverter;
 import com.sns.yourconnection.common.interceptor.RateLimitingInterceptor;
 import com.sns.yourconnection.common.resolver.AuthenticateUserResolver;
 import com.sns.yourconnection.common.resolver.ValidatedPageRequestResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -15,7 +18,16 @@ import java.util.stream.Stream;
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
     private final RateLimitingInterceptor rateLimitingInterceptor;
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        Stream.of(
+            new UserActivityConverter(),
+            new ContentActivityConverter()
+        ).forEach(registry::addConverter);
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/com/sns/yourconnection/common/converter/ContentActivityConverter.java
+++ b/src/main/java/com/sns/yourconnection/common/converter/ContentActivityConverter.java
@@ -1,0 +1,22 @@
+package com.sns.yourconnection.common.converter;
+
+import com.sns.yourconnection.exception.AppException;
+import com.sns.yourconnection.exception.ErrorCode;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
+import java.util.Locale;
+import org.springframework.core.convert.converter.Converter;
+
+public class ContentActivityConverter implements Converter<String, ContentActivity> {
+
+    @Override
+    public ContentActivity convert(String source) {
+        if (source == null) {
+            return ContentActivity.FLAGGED;
+        }
+        try {
+            return ContentActivity.valueOf(source.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new AppException(ErrorCode.NOT_EXIST_ACTIVITY, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/converter/UserActivityConverter.java
+++ b/src/main/java/com/sns/yourconnection/common/converter/UserActivityConverter.java
@@ -1,0 +1,23 @@
+package com.sns.yourconnection.common.converter;
+
+import com.sns.yourconnection.exception.AppException;
+import com.sns.yourconnection.exception.ErrorCode;
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
+import java.util.Locale;
+import org.springframework.core.convert.converter.Converter;
+
+
+public class UserActivityConverter implements Converter<String, UserActivity> {
+
+    @Override
+    public UserActivity convert(String source) {
+        if (source == null) {
+            return UserActivity.FLAGGED;
+        }
+        try {
+            return UserActivity.valueOf(source.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new AppException(ErrorCode.NOT_EXIST_ACTIVITY, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/sns/yourconnection/common/interceptor/RateLimitingInterceptor.java
+++ b/src/main/java/com/sns/yourconnection/common/interceptor/RateLimitingInterceptor.java
@@ -87,7 +87,6 @@ public class RateLimitingInterceptor implements HandlerInterceptor {
      * @apiNote 'X-RateLimit-RetryAfter', 'X-RateLimit-Limit', 'X-RateLimit-Remaining' 참고:
      * https://sendbird.com/docs/chat/v3/platform-api/application/understanding-rate-limits/rate-limits
      */
-    //TODO: response message ( custom response 객체 생성 후 구현 예정)
     private void successResponse(HttpServletResponse response, ConsumptionProbe consumptionProbe) {
         response.setHeader("X-RateLimit-Remaining",
             Long.toString(consumptionProbe.getRemainingTokens()));

--- a/src/main/java/com/sns/yourconnection/controller/AdminApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/AdminApiController.java
@@ -1,13 +1,33 @@
 package com.sns.yourconnection.controller;
 
+import static com.sns.yourconnection.controller.response.ResponseSuccess.*;
+
+import com.sns.yourconnection.common.annotation.ValidatedPageRequest;
+import com.sns.yourconnection.controller.response.PageResponseWrapper;
 import com.sns.yourconnection.controller.response.ResponseSuccess;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
 import com.sns.yourconnection.model.param.users.admin.AdminCreateRequest;
+import com.sns.yourconnection.model.param.users.admin.PostActivityRequest;
+import com.sns.yourconnection.model.param.users.admin.UserActivityRequest;
+import com.sns.yourconnection.model.result.users.admin.PostActivityResponse;
+import com.sns.yourconnection.model.result.report.PostReportResponse;
+import com.sns.yourconnection.model.result.report.UserReportResponse;
+import com.sns.yourconnection.model.result.users.admin.UserActivityResponse;
 import com.sns.yourconnection.service.admin.AdminCreationService;
+import com.sns.yourconnection.service.admin.ReportActionService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,13 +37,90 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminApiController {
 
     private final AdminCreationService adminCreationService;
+    private final ReportActionService reportActionService;
 
     @PostMapping("create")
     public ResponseSuccess<Void> createAdmin(@RequestBody AdminCreateRequest adminCreateRequest) {
-        log.info("[AdminApiController -> Called] Create admin account api has called ");
+        log.info("[AdminApiController -> Called : createAdmin] "
+            + "Create admin account api has called ");
         adminCreationService.createAccount(adminCreateRequest.getEmail());
 
-        log.info("[AdminApiController -> Completed] Admin account has been successfully created ");
-        return ResponseSuccess.response();
+        return response();
+    }
+
+    @GetMapping("/report/users")
+    public ResponseSuccess<List<UserActivityResponse>> getUserByActivity(
+        @RequestParam UserActivity activity, @ValidatedPageRequest Pageable pageable) {
+        log.info("[AdminApiController -> Called : getUserByActivity] get user by activity ");
+        Page<UserActivityResponse> userActivityPage = reportActionService.getUserByActivity(
+                activity, pageable)
+            .map(UserActivityResponse::fromUser);
+
+        return response(userActivityPage.getContent(),
+            PageResponseWrapper.fromPage(userActivityPage));
+    }
+
+    @GetMapping("/report/users/{userId}")
+    public ResponseSuccess<List<UserReportResponse>> getUserReportRecord(
+        @PathVariable Long userId, @ValidatedPageRequest Pageable pageable) {
+        log.info(
+            "[AdminApiController -> Called : getUserReportRecord] "
+                + "get report record for user : {}", userId);
+        Page<UserReportResponse> userReportPage = reportActionService.getUserReportRecord(userId,
+                pageable)
+            .map(UserReportResponse::fromUserReport);
+
+        return response(userReportPage.getContent(),
+            PageResponseWrapper.fromPage(userReportPage));
+    }
+
+    @GetMapping("/report/posts")
+    public ResponseSuccess<List<PostActivityResponse>> getPostByActivity(
+        @RequestParam ContentActivity activity, @ValidatedPageRequest Pageable pageable) {
+        log.info("[AdminApiController -> Called : getPostByActivity] get post by activity ");
+        Page<PostActivityResponse> postActivityPage = reportActionService.getPostByActivity(
+                activity, pageable)
+            .map(PostActivityResponse::fromPost);
+
+        return response(postActivityPage.getContent(),
+            PageResponseWrapper.fromPage(postActivityPage));
+    }
+
+    @GetMapping("/report/posts/{postId}")
+    public ResponseSuccess<List<PostReportResponse>> getPostReportRecord(
+        @PathVariable Long postId, @ValidatedPageRequest Pageable pageable) {
+        log.info(
+            "[AdminApiController -> Called : getPostReportRecord] "
+                + "get report record for post : {}", postId);
+        Page<PostReportResponse> postReportPage = reportActionService.getPostReportRecord(postId,
+                pageable)
+            .map(PostReportResponse::fromPostReport);
+
+        return response(postReportPage.getContent(),
+            PageResponseWrapper.fromPage(postReportPage));
+    }
+
+    @PutMapping("/report/users/{userId}")
+    public ResponseSuccess<UserActivityResponse> changeUserActivity(
+        @PathVariable Long userId, @RequestBody UserActivityRequest userActivityRequest) {
+        log.info(
+            "[AdminApiController -> Called : changeUserActivity] change user activity  "
+                + "user: {} activity : {}", userId, userActivityRequest.getUserActivity().name());
+        UserActivityResponse userActivityResponse = UserActivityResponse.fromUser(
+            reportActionService.changeUserActivity(userActivityRequest.getUserActivity(), userId));
+
+        return response(userActivityResponse);
+    }
+
+    @PutMapping("/report/posts/{postId}")
+    public ResponseSuccess<PostActivityResponse> changePostActivity(
+        @PathVariable Long postId, @RequestBody PostActivityRequest postActivityRequest) {
+        log.info(
+            "[AdminApiController -> Called : changePostActivity] change post activity  "
+                + "post: {} activity : {}", postId, postActivityRequest.getContentActivity().name());
+        PostActivityResponse postActivityResponse = PostActivityResponse.fromPost(
+            reportActionService.changePostActivity(postActivityRequest.getContentActivity(), postId));
+
+        return response(postActivityResponse);
     }
 }

--- a/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
+++ b/src/main/java/com/sns/yourconnection/controller/UserPublicApiController.java
@@ -53,7 +53,7 @@ public class UserPublicApiController {
         return response();
     }
 
-    @GetMapping("/emails/verifications")
+    @PostMapping("/emails/verifications")
     public ResponseSuccess<Void> verificationEmail(@RequestParam String email,
         @RequestBody SmtpVerifyRequest smtpVerifyRequest) {
         mailService.verifiedCode(email, smtpVerifyRequest.getSecurityCode());

--- a/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
+++ b/src/main/java/com/sns/yourconnection/exception/ErrorCode.java
@@ -44,12 +44,14 @@ public enum ErrorCode {
     HAS_NOT_PERMISSION_TO_ACCESS(HttpStatus.UNAUTHORIZED, "has not permission to access"),
     NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "no such algorithm"),
     NONE_MATCH(HttpStatus.NOT_FOUND, "can not find any match"),
-    USER_BANNED(HttpStatus.BAD_REQUEST, "already banned"),
+    USER_BANNED(HttpStatus.BAD_REQUEST, "Your account is currently banned and unavailable."),
     RESTRICTED_CONTENT(HttpStatus.BAD_REQUEST, "already restricted"),
+
     NOT_SUPPORT_FORMAT(HttpStatus.BAD_REQUEST, "not support to this format"),
     FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST,
         "Image upload failed, the image you selected may be in an unsupported format"),
     FAILED_RESIZE_IMAGE(HttpStatus.BAD_REQUEST, "image resize failed"),
+    NOT_EXIST_ACTIVITY(HttpStatus.BAD_REQUEST, "not exist activity"),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "invalid file type");
 
 

--- a/src/main/java/com/sns/yourconnection/model/dto/Post.java
+++ b/src/main/java/com/sns/yourconnection/model/dto/Post.java
@@ -1,6 +1,7 @@
 package com.sns.yourconnection.model.dto;
 
 import com.sns.yourconnection.model.entity.post.PostEntity;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +19,7 @@ public class Post {
     private LocalDateTime updatedAt;
     private String createdBy;
     private String updatedBy;
+    private ContentActivity contentActivity;
     private User user;
     private List<PostStorage> postStorage;
 
@@ -30,6 +32,7 @@ public class Post {
             postEntity.getUpdatedAt(),
             postEntity.getCreatedBy(),
             postEntity.getUpdatedBy(),
+            postEntity.getContentActivity(),
             User.fromEntity(postEntity.getUser()),
             PostStorageEntityToDTO(postEntity)
         );

--- a/src/main/java/com/sns/yourconnection/model/dto/PostReport.java
+++ b/src/main/java/com/sns/yourconnection/model/dto/PostReport.java
@@ -1,0 +1,27 @@
+package com.sns.yourconnection.model.dto;
+
+import com.sns.yourconnection.model.entity.report.PostReportEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostReport {
+
+    private User reporter;
+    private Post reportedPost;
+    private String content;
+    private LocalDateTime reportedAt;
+
+    public static PostReport fromEntity(PostReportEntity postReportEntity) {
+        return new PostReport(
+            User.fromEntity(postReportEntity.getReporter()),
+            Post.fromEntity(postReportEntity.getReportedPost()),
+            postReportEntity.getContent(),
+            postReportEntity.getReportedAt()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/dto/User.java
+++ b/src/main/java/com/sns/yourconnection/model/dto/User.java
@@ -1,5 +1,6 @@
 package com.sns.yourconnection.model.dto;
 
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
 import com.sns.yourconnection.model.entity.users.common.UserRole;
 import com.sns.yourconnection.model.entity.users.UserEntity;
 import java.util.Collection;
@@ -29,6 +30,8 @@ public class User implements UserDetails {
 
     private UserRole role;
 
+    private UserActivity activity;
+
     private LocalDateTime createdAt;
 
     private Map<String, Object> oAuth2Attributes;
@@ -42,6 +45,7 @@ public class User implements UserDetails {
             userEntity.getNickname(),
             userEntity.getEmail(),
             userEntity.getRole(),
+            userEntity.getUserActivity(),
             userEntity.getCreatedAt(),
             Map.of()
         );

--- a/src/main/java/com/sns/yourconnection/model/dto/UserReport.java
+++ b/src/main/java/com/sns/yourconnection/model/dto/UserReport.java
@@ -1,0 +1,27 @@
+package com.sns.yourconnection.model.dto;
+
+import com.sns.yourconnection.model.entity.report.UserReportEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserReport {
+
+    private User reporter;
+    private User reportedUser;
+    private String content;
+    private LocalDateTime reportedAt;
+
+    public static UserReport fromEntity(UserReportEntity userReportEntity) {
+        return new UserReport(
+            User.fromEntity(userReportEntity.getReporter()),
+            User.fromEntity(userReportEntity.getReportedUser()),
+            userReportEntity.getContent(),
+            userReportEntity.getReportedAt()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/entity/report/ContentActivity.java
+++ b/src/main/java/com/sns/yourconnection/model/entity/report/ContentActivity.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ContentActivity {
     GENERAL("일반 컨텐츠"),
-    ACTION_REQUIRED("선정성이 있는 컨텐츠"),
+    FLAGGED("선정성이 있는 컨텐츠"),
     RESTRICTED("제한된 컨텐츠");
 
     private final String description;
 }
+

--- a/src/main/java/com/sns/yourconnection/model/entity/users/common/UserActivity.java
+++ b/src/main/java/com/sns/yourconnection/model/entity/users/common/UserActivity.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum UserActivity {
 
     NORMAL("일반 유저"),
-    ACTION_REQUIRED("관리자의 조치가 필요한 유저"),
+    FLAGGED("신고받은 유저"),
     BAN("이용 제한 유저");
 
     private final String description;

--- a/src/main/java/com/sns/yourconnection/model/param/users/admin/PostActivityRequest.java
+++ b/src/main/java/com/sns/yourconnection/model/param/users/admin/PostActivityRequest.java
@@ -1,0 +1,14 @@
+package com.sns.yourconnection.model.param.users.admin;
+
+import com.sns.yourconnection.model.entity.report.ContentActivity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PostActivityRequest {
+
+    private ContentActivity contentActivity;
+}

--- a/src/main/java/com/sns/yourconnection/model/param/users/admin/UserActivityRequest.java
+++ b/src/main/java/com/sns/yourconnection/model/param/users/admin/UserActivityRequest.java
@@ -1,0 +1,14 @@
+package com.sns.yourconnection.model.param.users.admin;
+
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserActivityRequest {
+
+    private UserActivity userActivity;
+}

--- a/src/main/java/com/sns/yourconnection/model/result/report/PostReportResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/result/report/PostReportResponse.java
@@ -1,0 +1,27 @@
+package com.sns.yourconnection.model.result.report;
+
+import com.sns.yourconnection.model.dto.PostReport;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostReportResponse {
+
+    private Long reporterId;
+    private Long reportedPostId;
+    private String content;
+    private LocalDateTime reportedAt;
+
+    public static PostReportResponse fromPostReport(PostReport postReport) {
+        return new PostReportResponse(
+            postReport.getReporter().getId(),
+            postReport.getReportedPost().getId(),
+            postReport.getContent(),
+            postReport.getReportedAt()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/result/report/UserReportResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/result/report/UserReportResponse.java
@@ -1,0 +1,27 @@
+package com.sns.yourconnection.model.result.report;
+
+import com.sns.yourconnection.model.dto.UserReport;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserReportResponse {
+
+    private Long reporterId;
+    private Long reportedUserId;
+    private String content;
+    private LocalDateTime reportedAt;
+
+    public static UserReportResponse fromUserReport(UserReport userReport) {
+        return new UserReportResponse(
+            userReport.getReporter().getId(),
+            userReport.getReportedUser().getId(),
+            userReport.getContent(),
+            userReport.getReportedAt()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/model/result/users/admin/PostActivityResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/result/users/admin/PostActivityResponse.java
@@ -1,0 +1,33 @@
+package com.sns.yourconnection.model.result.users.admin;
+
+import com.sns.yourconnection.model.dto.Post;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PostActivityResponse {
+
+    private Long postId;
+    private String createdBy;
+    private String updatedBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private ContentActivity contentActivity;
+
+    public static PostActivityResponse fromPost(Post post) {
+        return new PostActivityResponse(
+            post.getId(),
+            post.getCreatedBy(),
+            post.getUpdatedBy(),
+            post.getCreatedAt(),
+            post.getUpdatedAt(),
+            post.getContentActivity()
+        );
+    }
+
+}

--- a/src/main/java/com/sns/yourconnection/model/result/users/admin/UserActivityResponse.java
+++ b/src/main/java/com/sns/yourconnection/model/result/users/admin/UserActivityResponse.java
@@ -1,0 +1,30 @@
+package com.sns.yourconnection.model.result.users.admin;
+
+import com.sns.yourconnection.model.dto.User;
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
+import com.sns.yourconnection.model.entity.users.common.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserActivityResponse {
+
+    private Long userId;
+    private String username;
+    private String nickname;
+    private UserRole userRole;
+    private UserActivity userActivity;
+
+    public static UserActivityResponse fromUser(User user) {
+        return new UserActivityResponse(
+            user.getId(),
+            user.getUsername(),
+            user.getNickname(),
+            user.getRole(),
+            user.getActivity()
+        );
+    }
+}

--- a/src/main/java/com/sns/yourconnection/repository/PostReportRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/PostReportRepository.java
@@ -2,7 +2,10 @@ package com.sns.yourconnection.repository;
 
 import com.sns.yourconnection.model.entity.post.PostEntity;
 import com.sns.yourconnection.model.entity.report.PostReportEntity;
+import com.sns.yourconnection.model.entity.report.UserReportEntity;
 import com.sns.yourconnection.model.entity.users.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +15,6 @@ public interface PostReportRepository extends JpaRepository<PostReportEntity, Lo
     Integer countByReportedPost(PostEntity reportedPost);
 
     boolean existsByReporterAndReportedPost(UserEntity reporter, PostEntity reportedPost);
+
+    Page<PostReportEntity> findByReportedPost(PostEntity reportedPost, Pageable pageable);
 }

--- a/src/main/java/com/sns/yourconnection/repository/PostRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.sns.yourconnection.repository;
 
 import com.sns.yourconnection.model.entity.post.PostEntity;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,6 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
     @Query("SELECT p FROM PostEntity p WHERE (:keyword IS NULL OR :keyword = '') OR p.title LIKE %:keyword%")
     Page<PostEntity> searchByKeyword(@Param(value = "keyword") String keyword, Pageable pageable);
+
+    Page<PostEntity> findByContentActivity(ContentActivity contentActivity,Pageable pageable);
 }

--- a/src/main/java/com/sns/yourconnection/repository/UserReportRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/UserReportRepository.java
@@ -2,6 +2,8 @@ package com.sns.yourconnection.repository;
 
 import com.sns.yourconnection.model.entity.report.UserReportEntity;
 import com.sns.yourconnection.model.entity.users.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,6 @@ public interface UserReportRepository extends JpaRepository<UserReportEntity, Lo
     Integer countByReportedUser(UserEntity reportedUser);
 
     boolean existsByReporterAndReportedUser(UserEntity reporter, UserEntity reportedUser);
+
+    Page<UserReportEntity> findByReportedUser(UserEntity reportedUser, Pageable pageable);
 }

--- a/src/main/java/com/sns/yourconnection/repository/UserRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.sns.yourconnection.repository;
 
 import com.sns.yourconnection.model.entity.users.UserEntity;
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +16,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUsername(String username);
 
     List<UserEntity> findByEmail(String email);
+
+    Page<UserEntity> findByUserActivity(UserActivity userActivity, Pageable pageable);
 }

--- a/src/main/java/com/sns/yourconnection/service/ReportService.java
+++ b/src/main/java/com/sns/yourconnection/service/ReportService.java
@@ -50,7 +50,7 @@ public class ReportService {
         userReportRepository.save(UserReportEntity.of(reporterEntity, reportedUserEntity, text));
 
         if (userReportRepository.countByReportedUser(reportedUserEntity) > REPORT_LIMIT) {
-            reportedUserEntity.changeActivity(UserActivity.ACTION_REQUIRED);
+            reportedUserEntity.changeActivity(UserActivity.FLAGGED);
         }
     }
 
@@ -78,7 +78,7 @@ public class ReportService {
         postReportRepository.save(PostReportEntity.of(reporterEntity, reportedPostEntity, text));
 
         if (postReportRepository.countByReportedPost(reportedPostEntity) > REPORT_LIMIT) {
-            reportedPostEntity.changeActivity(ContentActivity.ACTION_REQUIRED);
+            reportedPostEntity.changeActivity(ContentActivity.FLAGGED);
         }
     }
 

--- a/src/main/java/com/sns/yourconnection/service/admin/AdminCreationService.java
+++ b/src/main/java/com/sns/yourconnection/service/admin/AdminCreationService.java
@@ -24,12 +24,12 @@ public class AdminCreationService {
     private final JavaMailSender javaMailSender;
 
 
-//    @PostConstruct
-//    public void initAdmin() {
-//        if (userRepository.findByEmail(projectDefaultMail).isEmpty()) {
-//            createAccount(projectDefaultMail);
-//        }
-//    }
+    @PostConstruct
+    public void initAdmin() {
+        if (userRepository.findByEmail(projectDefaultMail).isEmpty()) {
+            createAccount(projectDefaultMail);
+        }
+    }
 
     @Transactional
     public void createAccount(String email) {

--- a/src/main/java/com/sns/yourconnection/service/admin/ReportActionService.java
+++ b/src/main/java/com/sns/yourconnection/service/admin/ReportActionService.java
@@ -1,0 +1,77 @@
+package com.sns.yourconnection.service.admin;
+
+import com.sns.yourconnection.exception.AppException;
+import com.sns.yourconnection.exception.ErrorCode;
+import com.sns.yourconnection.model.dto.Post;
+import com.sns.yourconnection.model.dto.PostReport;
+import com.sns.yourconnection.model.dto.User;
+import com.sns.yourconnection.model.dto.UserReport;
+import com.sns.yourconnection.model.entity.post.PostEntity;
+import com.sns.yourconnection.model.entity.report.ContentActivity;
+import com.sns.yourconnection.model.entity.users.UserEntity;
+import com.sns.yourconnection.model.entity.users.common.UserActivity;
+import com.sns.yourconnection.repository.PostReportRepository;
+import com.sns.yourconnection.repository.PostRepository;
+import com.sns.yourconnection.repository.UserReportRepository;
+import com.sns.yourconnection.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+/**
+ * 신고 내역과 userActivity 값을 admin 권한으로 관리할 수 있는 서비스 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ReportActionService {
+
+    private final UserReportRepository userReportRepository;
+    private final UserRepository userRepository;
+    private final PostReportRepository postReportRepository;
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public Page<User> getUserByActivity(UserActivity userActivity, Pageable pageable) {
+        return userRepository.findByUserActivity(userActivity, pageable)
+            .map(User::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserReport> getUserReportRecord(Long userId, Pageable pageable) {
+        UserEntity userEntity = userRepository.findById(userId)
+            .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        return userReportRepository.findByReportedUser(userEntity, pageable)
+            .map(UserReport::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Post> getPostByActivity(ContentActivity contentActivity, Pageable pageable) {
+        return postRepository.findByContentActivity(contentActivity, pageable)
+            .map(Post::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostReport> getPostReportRecord(Long postId, Pageable pageable) {
+        PostEntity postEntity = postRepository.findById(postId)
+            .orElseThrow(() -> new AppException(ErrorCode.POST_DOES_NOT_EXIST));
+        return postReportRepository.findByReportedPost(postEntity, pageable)
+            .map(PostReport::fromEntity);
+    }
+
+    @Transactional
+    public User changeUserActivity(UserActivity userActivity, Long userId) {
+        UserEntity userEntity = userRepository.findById(userId)
+            .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        userEntity.changeActivity(userActivity);
+        return User.fromEntity(userEntity);
+    }
+
+    @Transactional
+    public Post changePostActivity(ContentActivity contentActivity, Long postId) {
+        PostEntity postEntity = postRepository.findById(postId)
+            .orElseThrow(() -> new AppException(ErrorCode.POST_DOES_NOT_EXIST));
+        postEntity.changeActivity(contentActivity);
+        return Post.fromEntity(postEntity);
+    }
+}


### PR DESCRIPTION
## Summary

어드민 신고 조치 서비스 구현

## Details
### Activity 값 변경 및 개선
- activity 값 REQUIRED_ACTION -> FLAGGED 네이밍 수정 (기능은 같음)
- enum 클래스인 activity 값을 url로 데이터 바이딩 받기 위해 converter 클래스 생성 및 webConfig 설정
### 어드민 신고 조치 서비스 구현
- 어드민 권한을 가진 유저만 해당 서비스 이용 가능
- activity 값을 기준으로 user, content 조회
- 특정 유저, 게시물에 대한 신고 내역 확인
- 유저, 게시물에 대한 activity 값 변경
### 유저 필터링
- userActivity 값 -> ban일 경우 api 접근 불가능
- 단, public api는 접근 가능


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #79 
