### PR TITLE
Feature/#95 ratelimit refactor

### DIFF
--- a/src/main/java/com/sns/yourconnection/YourConnectionApplication.java
+++ b/src/main/java/com/sns/yourconnection/YourConnectionApplication.java
@@ -15,5 +15,4 @@ public class YourConnectionApplication {
     public static void main(String[] args) {
         SpringApplication.run(YourConnectionApplication.class, args);
     }
-
 }

--- a/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditorAwareImpl.java
+++ b/src/main/java/com/sns/yourconnection/common/configuration/auditor/AuditorAwareImpl.java
@@ -2,8 +2,7 @@ package com.sns.yourconnection.common.configuration.auditor;
 
 
 import com.sns.yourconnection.security.principal.UserPrincipal;
-import com.sns.yourconnection.utils.loader.ClassUtil;
-import lombok.extern.slf4j.Slf4j;
+import com.sns.yourconnection.utils.validation.ClassUtil;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;

--- a/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
+++ b/src/main/java/com/sns/yourconnection/common/resolver/AuthenticateUserResolver.java
@@ -3,7 +3,7 @@ package com.sns.yourconnection.common.resolver;
 import com.sns.yourconnection.common.annotation.AuthUser;
 import com.sns.yourconnection.model.dto.User;
 import com.sns.yourconnection.security.principal.UserPrincipal;
-import com.sns.yourconnection.utils.loader.ClassUtil;
+import com.sns.yourconnection.utils.validation.ClassUtil;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/sns/yourconnection/controller/response/ratelimit/RateLimitResponse.java
+++ b/src/main/java/com/sns/yourconnection/controller/response/ratelimit/RateLimitResponse.java
@@ -1,0 +1,36 @@
+package com.sns.yourconnection.controller.response.ratelimit;
+
+import com.sns.yourconnection.exception.ErrorCode;
+import java.time.Duration;
+import javax.servlet.http.HttpServletResponse;
+
+public class RateLimitResponse {
+
+    /**
+     * @apiNote 'X-RateLimit-RetryAfter', 'X-RateLimit-Limit', 'X-RateLimit-Remaining' 참고:
+     * https://sendbird.com/docs/chat/v3/platform-api/application/understanding-rate-limits/rate-limits
+     * @apiNote `Retry-After` 참고:
+     * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+     */
+    public static void successResponse(HttpServletResponse response,
+        long remainingTokens, Long bucketCapacity, Duration callsInSeconds) {
+
+        response.setHeader("X-RateLimit-Remaining",
+            Long.toString(remainingTokens));
+
+        response.setHeader("X-RateLimit-Limit",
+            bucketCapacity + ";w=" + callsInSeconds.getSeconds());
+    }
+
+    public static void errorResponse(HttpServletResponse response,
+        Long bucketCapacity, Duration callsInSeconds, float waitForRefill) {
+
+        response.setHeader("X-RateLimit-RetryAfter",
+            Float.toString(waitForRefill));
+
+        response.setHeader("X-RateLimit-Limit",
+            bucketCapacity + ";w=" + callsInSeconds.getSeconds());
+
+        response.setStatus(ErrorCode.TOO_MANY_REQUESTS.getHttpStatus().value());
+    }
+}

--- a/src/main/java/com/sns/yourconnection/repository/UserRevisionRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/UserRevisionRepository.java
@@ -2,7 +2,7 @@ package com.sns.yourconnection.repository;
 
 import com.sns.yourconnection.model.entity.users.UserActivity;
 import com.sns.yourconnection.model.entity.users.UserEntity;
-import com.sns.yourconnection.utils.loader.ClassUtil;
+import com.sns.yourconnection.utils.validation.ClassUtil;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.envers.AuditReader;

--- a/src/main/java/com/sns/yourconnection/repository/redis/LoginFailedRepository.java
+++ b/src/main/java/com/sns/yourconnection/repository/redis/LoginFailedRepository.java
@@ -1,8 +1,6 @@
 package com.sns.yourconnection.repository.redis;
 
-import com.sns.yourconnection.utils.loader.ClassUtil;
 import com.sns.yourconnection.utils.loader.LuaScriptLoader;
-import java.time.Duration;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sns/yourconnection/service/protection/RateLimitService.java
+++ b/src/main/java/com/sns/yourconnection/service/protection/RateLimitService.java
@@ -46,6 +46,7 @@ public class RateLimitService {
     private void checkAndResetIfLimitExceeded(String clientIp, RequestInfo requestInfo, int count) {
         if (count >= 10) {
             requestInfo.resetCount();
+
             notificationService.sendMessage(
                 String.format(" Rate limit is occurred 10 or more times for this client IP: %s",
                     clientIp));

--- a/src/main/java/com/sns/yourconnection/utils/checker/RateLimitRefillChecker.java
+++ b/src/main/java/com/sns/yourconnection/utils/checker/RateLimitRefillChecker.java
@@ -1,0 +1,15 @@
+package com.sns.yourconnection.utils.checker;
+
+import io.github.bucket4j.ConsumptionProbe;
+import java.util.concurrent.TimeUnit;
+
+public class RateLimitRefillChecker {
+
+    public static float getRoundedSecondsToWaitForRefill(ConsumptionProbe consumptionProbe) {
+        float secondsToWaitForRefill =
+            (float) TimeUnit.NANOSECONDS.toMillis(
+                consumptionProbe.getNanosToWaitForRefill()) / 1000;
+
+        return (float) Math.round(secondsToWaitForRefill * 10) / 10;
+    }
+}

--- a/src/main/java/com/sns/yourconnection/utils/constants/RateLimitBucketConstants.java
+++ b/src/main/java/com/sns/yourconnection/utils/constants/RateLimitBucketConstants.java
@@ -1,0 +1,18 @@
+package com.sns.yourconnection.utils.constants;
+
+import java.time.Duration;
+
+/**
+ * @apiNote # BUCKET_CAPACITY : 버킷의 총 크기 (용량)
+ *          # BUCKET_TOKENS : 시간당 버킷안에 충전되는 토큰의 수
+ *          # CALLS_IN_SECONDS : 버킷 충전 시간
+ *          # REQUEST_COST_IN_TOKENS : 1회 요청당 소비되는 토큰 수
+ */
+public class RateLimitBucketConstants {
+
+    public static final Long BUCKET_CAPACITY = 10L;
+    public static final Long BUCKET_TOKENS = 10L;
+    public static final Duration CALLS_IN_SECONDS = Duration.ofSeconds(1);
+    public static final Integer REQUEST_COST_IN_TOKENS = 1;
+
+}

--- a/src/main/java/com/sns/yourconnection/utils/validation/ClassUtil.java
+++ b/src/main/java/com/sns/yourconnection/utils/validation/ClassUtil.java
@@ -1,4 +1,4 @@
-package com.sns.yourconnection.utils.loader;
+package com.sns.yourconnection.utils.validation;
 
 import com.sns.yourconnection.model.dto.User;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sns/yourconnection/utils/validation/ClientIpUtil.java
+++ b/src/main/java/com/sns/yourconnection/utils/validation/ClientIpUtil.java
@@ -3,13 +3,9 @@ package com.sns.yourconnection.utils.validation;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.servlet.http.HttpServletRequest;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 
-@Slf4j
-public class HttpReqRespUtil {
+public class ClientIpUtil {
     private static final String[] IP_HEADER_CANDIDATES = {
             "X-Forwarded-For",
             "Proxy-Client-IP",
@@ -31,9 +27,11 @@ public class HttpReqRespUtil {
     public static String getClientIp(HttpServletRequest request) {
         return Arrays.stream(IP_HEADER_CANDIDATES)
                 .map(request::getHeader)
+
                 .filter(ipAddress -> ipAddress != null && !ipAddress.isEmpty() && !"unknown".equalsIgnoreCase(ipAddress))
                 .map(ipAddress -> ipAddress.split(",")[0])
                 .findFirst()
+
                 .orElseGet(request::getRemoteAddr);
     }
 }


### PR DESCRIPTION
## Summary

Rate limit refactor 

## Details
- 기존의 `RateLimitingInterceptor`클래스의 역할이 너무 많다고 판단
- 상수 선언 부분을`RateLimitBucketConstants` 유틸 클래스로 별도 분리
- response 관련 부분을 `RateLimitResponse` 클래스로 분리

### 해당 내용 정리

<a href="https://velog.io/@whcksdud8/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-Rate-limit-%ED%95%B8%EB%93%A4%EB%A7%81-%EB%B0%8F-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81" target="_blank">rate limit 핸들링 및 에러 모니터링</a>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 작성 및 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
## Issue Check
* resolved: #95 
